### PR TITLE
Add ability to ignore limit switches when climbing

### DIFF
--- a/Competition2017/src/competition/operator_interface/OperatorCommandMap.java
+++ b/Competition2017/src/competition/operator_interface/OperatorCommandMap.java
@@ -58,6 +58,7 @@ public class OperatorCommandMap {
             RopeAlignerCommand aligner)   
     {
         oi.controller.getXboxButton(XboxButton.X).whileHeld(ascend);
+        oi.operatorPanelButtons.getifAvailable(4).whileHeld(ascend);
         
         oi.controller.getXboxButton(XboxButton.Start).whileHeld(aligner);
         oi.controller.getXboxButton(XboxButton.Back).whileHeld(ascendDangerously);

--- a/Competition2017/src/competition/operator_interface/OperatorCommandMap.java
+++ b/Competition2017/src/competition/operator_interface/OperatorCommandMap.java
@@ -8,8 +8,8 @@ import xbot.common.subsystems.pose.commands.ResetDistanceCommand;
 import xbot.common.subsystems.pose.commands.SetRobotHeadingCommand;
 import xbot.common.controls.sensors.XXboxController.XboxButton;
 import xbot.common.properties.DoubleProperty;
-
-import competition.subsystems.climbing.commands.AscendCommand;
+import competition.subsystems.climbing.commands.AscendDangerouslyCommand;
+import competition.subsystems.climbing.commands.AscendSafelyCommand;
 import competition.subsystems.climbing.commands.DescendClimbingCommand;
 import competition.subsystems.agitator.AgitatorsManagerSubsystem;
 import competition.subsystems.agitator.commands.EjectAgitatorCommand;
@@ -53,13 +53,15 @@ public class OperatorCommandMap {
     public void setupClimbingCommands(
             OperatorInterface oi,
             DescendClimbingCommand descend,
-            AscendCommand ascend,
+            AscendSafelyCommand ascend,
+            AscendDangerouslyCommand ascendDangerously,
             RopeAlignerCommand aligner)   
     {
         oi.controller.getXboxButton(XboxButton.Y).whileHeld(descend);
         oi.controller.getXboxButton(XboxButton.X).whileHeld(ascend);
         
         oi.controller.getXboxButton(XboxButton.Start).whileHeld(aligner);
+        oi.controller.getXboxButton(XboxButton.Back).whileHeld(ascendDangerously);
     }
     
     @Inject

--- a/Competition2017/src/competition/subsystems/climbing/ClimbingSubsystem.java
+++ b/Competition2017/src/competition/subsystems/climbing/ClimbingSubsystem.java
@@ -36,6 +36,8 @@ public class ClimbingSubsystem extends BaseSubsystem implements PeriodicDataSour
         ascendPowerProperty = propManager.createPersistentProperty("Climber ascend power", 0.5);
         
         climbingMotor.createTelemetryProperties("Climbing motor", propManager);
+        
+        climbingMotor.enableLimitSwitches(true, false);
     }
 
     public void stop() {
@@ -55,6 +57,10 @@ public class ClimbingSubsystem extends BaseSubsystem implements PeriodicDataSour
     
     public void setBrake(boolean brakeOn) {
         brakeSolenoid.set(brakeOn);
+    }
+    
+    public boolean isLimitSwitchPressed() {
+        return climbingMotor.isForwardLimitSwitchClosed();
     }
 
     @Override

--- a/Competition2017/src/competition/subsystems/climbing/ClimbingSubsystem.java
+++ b/Competition2017/src/competition/subsystems/climbing/ClimbingSubsystem.java
@@ -62,6 +62,10 @@ public class ClimbingSubsystem extends BaseSubsystem implements PeriodicDataSour
     public boolean isLimitSwitchPressed() {
         return climbingMotor.isForwardLimitSwitchClosed();
     }
+    
+    public void setEnableSafeties(boolean isEnabled) {
+        climbingMotor.enableLimitSwitches(isEnabled, isEnabled);
+    }
 
     @Override
     public void updatePeriodicData() {

--- a/Competition2017/src/competition/subsystems/climbing/ClimbingSubsystem.java
+++ b/Competition2017/src/competition/subsystems/climbing/ClimbingSubsystem.java
@@ -64,7 +64,7 @@ public class ClimbingSubsystem extends BaseSubsystem implements PeriodicDataSour
     }
     
     public void setEnableSafeties(boolean isEnabled) {
-        climbingMotor.enableLimitSwitches(isEnabled, isEnabled);
+        climbingMotor.enableLimitSwitches(isEnabled, false);
     }
 
     @Override

--- a/Competition2017/src/competition/subsystems/climbing/commands/AscendCommand.java
+++ b/Competition2017/src/competition/subsystems/climbing/commands/AscendCommand.java
@@ -16,6 +16,10 @@ public class AscendCommand extends BaseClimbingCommand {
     }
 
     public void execute() {
-        climbingSubsystem.ascend();
+        if (climbingSubsystem.isLimitSwitchPressed()) {
+            climbingSubsystem.stop();
+        } else {
+            climbingSubsystem.ascend();
+        }
     }
 }

--- a/Competition2017/src/competition/subsystems/climbing/commands/AscendDangerouslyCommand.java
+++ b/Competition2017/src/competition/subsystems/climbing/commands/AscendDangerouslyCommand.java
@@ -1,0 +1,20 @@
+package competition.subsystems.climbing.commands;
+
+import com.google.inject.Inject;
+
+import competition.subsystems.climbing.ClimbingSubsystem;
+
+public class AscendDangerouslyCommand extends AscendSafelyCommand {
+
+    @Inject
+    public AscendDangerouslyCommand(ClimbingSubsystem climbingSubsystem) {
+        super(climbingSubsystem);
+    }
+    
+    @Override
+    public void initialize() {
+        super.initialize();
+        climbingSubsystem.setEnableSafeties(false);
+    }
+
+}

--- a/Competition2017/src/competition/subsystems/climbing/commands/AscendSafelyCommand.java
+++ b/Competition2017/src/competition/subsystems/climbing/commands/AscendSafelyCommand.java
@@ -4,22 +4,19 @@ import com.google.inject.Inject;
 
 import competition.subsystems.climbing.ClimbingSubsystem;
 
-public class AscendCommand extends BaseClimbingCommand {
+public class AscendSafelyCommand extends BaseClimbingCommand {
 
     @Inject
-    public AscendCommand(ClimbingSubsystem climbingSubsystem) {
+    public AscendSafelyCommand(ClimbingSubsystem climbingSubsystem) {
         super(climbingSubsystem);
     }
 
     public void initialize() {
         log.info("Initializing");
+        climbingSubsystem.setEnableSafeties(true);
     }
 
     public void execute() {
-        if (climbingSubsystem.isLimitSwitchPressed()) {
-            climbingSubsystem.stop();
-        } else {
-            climbingSubsystem.ascend();
-        }
+        climbingSubsystem.ascend();
     }
 }


### PR DESCRIPTION
Adds an `AscendDangerouslyCommand` that will run the climber even if limit switches are pressed.