### PR TITLE
Use new, simpler persistent property manager from CommonLib. 

### DIFF
--- a/Competition2017/robot-program-build.properties
+++ b/Competition2017/robot-program-build.properties
@@ -23,12 +23,11 @@ guice_assisted.jar=${commonlib.libs}/guice-3.0/guice-assistedinject-3.0.jar
 inject.jar=${commonlib.libs}/guice-3.0/javax.inject.jar
 log4j.jar=${commonlib.libs}/log4j/log4j-1.2.17.jar
 commonsio.jar=${commonlib.libs}/commons-io-2.4/commons-io-2.4.jar
-derby.jar=${commonlib.libs}/derby/derby.jar
 junit.jars=${commonlib.libs}/hamcrest-core-1.3.jar:${commonlib.libs}/junit-4.12.jar
 opencv.jar=${commonlib.libs}/opencv.jar
 ctre.jar=${commonlib.libs}/CTRLib.jar
 
-thirdpartyjars=${guice.jar}:${guice_assisted.jar}:${inject.jar}:${derby.jar}:${log4j.jar}:${commonsio.jar}:${opencv.jar}:${ctre.jar}
+thirdpartyjars=${guice.jar}:${guice_assisted.jar}:${inject.jar}:${log4j.jar}:${commonsio.jar}:${opencv.jar}:${ctre.jar}
 
 classpath=${wpilib.jar}:${networktables.jar}:${thirdpartyjars}:${commonlib.jar}
 

--- a/Competition2017/travis-build.properties
+++ b/Competition2017/travis-build.properties
@@ -20,11 +20,10 @@ guice_assisted.jar=${commonlib.libs}/guice-3.0/guice-assistedinject-3.0.jar
 inject.jar=${commonlib.libs}/guice-3.0/javax.inject.jar
 log4j.jar=${commonlib.libs}/log4j/log4j-1.2.17.jar
 commonsio.jar=${commonlib.libs}/commons-io-2.4/commons-io-2.4.jar
-derby.jar=${commonlib.libs}/Derby/derby.jar
 junit.jars=${commonlib.libs}/hamcrest-core-1.3.jar:${commonlib.libs}/junit-4.12.jar
 ctre.jar=${commonlib.libs}/CTRLib.jar
 
-thirdpartyjars=${guice.jar}:${guice_assisted.jar}:${inject.jar}:${derby.jar}:${log4j.jar}:${commonsio.jar}:${ctre.jar}
+thirdpartyjars=${guice.jar}:${guice_assisted.jar}:${inject.jar}:${log4j.jar}:${commonsio.jar}:${ctre.jar}
 
 classpath=${wpilib.jar}:${networktables.jar}:${thirdpartyjars}:${commonlib.jar}
 


### PR DESCRIPTION
Mostly this means removing Derby jars.